### PR TITLE
Fix fonts for non-latin letters

### DIFF
--- a/ArkadiusTradeTools/ArkadiusTradeTools.xml
+++ b/ArkadiusTradeTools/ArkadiusTradeTools.xml
@@ -86,7 +86,7 @@
                     <Anchor point="TOPLEFT" relativeTo="$(parent)" relativePoint="TOPLEFT" offsetX="0" offsetY="0" />
                     <Anchor point="BOTTOMRIGHT" relativeTo="$(parent)" relativePoint="TOPRIGHT" offsetX="0" offsetY="80" />
                     <Controls>
-                        <Label name="$(parent)Caption" text="Arkadius' Trade Tools" color="FFFFFF" horizontalAlignment="LEFT" verticalAlignment="CENTER" font="EsoUI/Common/Fonts/ProseAntiquePSMT.otf|18">
+                        <Label name="$(parent)Caption" text="Arkadius' Trade Tools" color="FFFFFF" horizontalAlignment="LEFT" verticalAlignment="CENTER" font="$(ANTIQUE_FONT)|18">
                             <Anchor point="TOPLEFT" relativeTo="$(parent)" relativePoint="TOPLEFT" offsetX="10" offsetY="10" />
                         </Label>
                         <Button name="$(parent)Close">

--- a/ArkadiusTradeTools/ArkadiusTradeToolsTemplates.xml
+++ b/ArkadiusTradeTools/ArkadiusTradeToolsTemplates.xml
@@ -37,7 +37,7 @@
                     <Dimensions x="20" y="20" />
                     <Anchor point="LEFT" relativeTo="$(parent)" relativePoint="LEFT" offsetX="15" offsetY="0"/>
                 </Texture>
-                <Label name="$(parent)Text" text="Sales" horizontalAlignment="LEFT" verticalAlignment="CENTER" font="EsoUI/Common/Fonts/ProseAntiquePSMT.otf|15" color="FFFFFF">
+                <Label name="$(parent)Text" text="Sales" horizontalAlignment="LEFT" verticalAlignment="CENTER" font="$(ANTIQUE_FONT)|15" color="FFFFFF">
                     <Anchor point="LEFT" relativeTo="$(parent)Icon" relativePoint="RIGHT" offsetX="0" offsetY="0"/>
                 </Label>
             </Controls>
@@ -221,7 +221,7 @@
                 end
             </OnInitialized>
             <Controls>
-                <Label name="$(parent)Index" inheritAlpha="true" verticalAlignment="TOP" horizontalAlignment="LEFT" font="EsoUI/Common/Fonts/ProseAntiquePSMT.otf|12">
+                <Label name="$(parent)Index" inheritAlpha="true" verticalAlignment="TOP" horizontalAlignment="LEFT" font="$(ANTIQUE_FONT)|12">
                     <Anchor point="TOPLEFT" relativeTo="$(parent)" relativePoint="TOPLEFT" offsetX="0" offsetY="-4"/>
                 </Label>
             </Controls>

--- a/ArkadiusTradeToolsExports/ArkadiusTradeToolsExports.xml
+++ b/ArkadiusTradeToolsExports/ArkadiusTradeToolsExports.xml
@@ -137,21 +137,21 @@
         <Control name="ArkadiusTradeToolsExportsRow" inherits="ArkadiusTradeToolsListRow" virtual="true">
             <Controls>
                 <Texture name="$(parent)BG" inherits="ZO_ThinListBgStrip" />
-                <Label name="$(parent)GuildName" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="LEFT" wrapMode="ELLIPSIS" font="EsoUI/Common/Fonts/ProseAntiquePSMT.otf|15">
+                <Label name="$(parent)GuildName" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="LEFT" wrapMode="ELLIPSIS" font="$(ANTIQUE_FONT)|15">
                     <Anchor point="TOPLEFT" relativeTo="$(parent)" relativePoint="TOPLEFT" offsetX="0" offsetY="0"/>
                     <Anchor point="BOTTOMLEFT" relativeTo="$(parent)" relativePoint="BOTTOMLEFT" offsetX="0" offsetY="0"/>
                 </Label>
-                <Label name="$(parent)StartTimeStamp" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="RIGHT" wrapMode="ELLIPSIS" font="EsoUI/Common/Fonts/ProseAntiquePSMT.otf|15">
+                <Label name="$(parent)StartTimeStamp" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="RIGHT" wrapMode="ELLIPSIS" font="$(ANTIQUE_FONT)|15">
                     <Dimensions x="125" />
                     <Anchor point="TOPLEFT" relativeTo="$(parent)GuildName" relativePoint="TOPRIGHT" offsetX="10" offsetY="0"/>
                     <Anchor point="BOTTOMLEFT" relativeTo="$(parent)GuildName" relativePoint="BOTTOMRIGHT" offsetX="10" offsetY="0"/>
                 </Label>
-                <Label name="$(parent)EndTimeStamp" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="RIGHT" wrapMode="ELLIPSIS" font="EsoUI/Common/Fonts/ProseAntiquePSMT.otf|15">
+                <Label name="$(parent)EndTimeStamp" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="RIGHT" wrapMode="ELLIPSIS" font="$(ANTIQUE_FONT)|15">
                     <Dimensions x="125" />
                     <Anchor point="TOPLEFT" relativeTo="$(parent)StartTimeStamp" relativePoint="TOPRIGHT" offsetX="10" offsetY="0"/>
                     <Anchor point="BOTTOMLEFT" relativeTo="$(parent)StartTimeStamp" relativePoint="BOTTOMRIGHT" offsetX="10" offsetY="0"/>
                 </Label>
-                <Label name="$(parent)CreatedTimeStamp" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="RIGHT" wrapMode="ELLIPSIS" font="EsoUI/Common/Fonts/ProseAntiquePSMT.otf|15">
+                <Label name="$(parent)CreatedTimeStamp" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="RIGHT" wrapMode="ELLIPSIS" font="$(ANTIQUE_FONT)|15">
                     <Dimensions x="125" />
                     <Anchor point="TOPLEFT" relativeTo="$(parent)EndTimeStamp" relativePoint="TOPRIGHT" offsetX="10" offsetY="0"/>
                     <Anchor point="BOTTOMLEFT" relativeTo="$(parent)EndTimeStamp" relativePoint="BOTTOMRIGHT" offsetX="10" offsetY="0"/>

--- a/ArkadiusTradeToolsPurchases/ArkadiusTradeToolsPurchases.xml
+++ b/ArkadiusTradeToolsPurchases/ArkadiusTradeToolsPurchases.xml
@@ -158,15 +158,15 @@
         <Control name="ArkadiusTradeToolsPurchasesRow" inherits="ArkadiusTradeToolsListRow" virtual="true">
             <Controls>
                 <Texture name="$(parent)BG" inherits="ZO_ThinListBgStrip" />
-                <Label name="$(parent)BuyerName" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="LEFT" wrapMode="ELLIPSIS" font="EsoUI/Common/Fonts/ProseAntiquePSMT.otf|15">
+                <Label name="$(parent)BuyerName" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="LEFT" wrapMode="ELLIPSIS" font="$(ANTIQUE_FONT)|15">
                     <Anchor point="TOPLEFT" relativeTo="$(parent)" relativePoint="TOPLEFT" offsetX="0" offsetY="0"/>
                     <Anchor point="BOTTOMLEFT" relativeTo="$(parent)" relativePoint="BOTTOMLEFT" offsetX="0" offsetY="0"/>
                 </Label>
-                <Label name="$(parent)SellerName" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="LEFT" wrapMode="ELLIPSIS" font="EsoUI/Common/Fonts/ProseAntiquePSMT.otf|15">
+                <Label name="$(parent)SellerName" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="LEFT" wrapMode="ELLIPSIS" font="$(ANTIQUE_FONT)|15">
                     <Anchor point="TOPLEFT" relativeTo="$(parent)BuyerName" relativePoint="TOPRIGHT" offsetX="10" offsetY="0"/>
                     <Anchor point="BOTTOMLEFT" relativeTo="$(parent)BuyerName" relativePoint="BOTTOMRIGHT" offsetX="10" offsetY="0"/>
                 </Label>
-                <Label name="$(parent)GuildName" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="LEFT" wrapMode="ELLIPSIS" font="EsoUI/Common/Fonts/ProseAntiquePSMT.otf|15">
+                <Label name="$(parent)GuildName" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="LEFT" wrapMode="ELLIPSIS" font="$(ANTIQUE_FONT)|15">
                     <Anchor point="TOPLEFT" relativeTo="$(parent)SellerName" relativePoint="TOPRIGHT" offsetX="10" offsetY="0"/>
                     <Anchor point="BOTTOMLEFT" relativeTo="$(parent)SellerName" relativePoint="BOTTOMRIGHT" offsetX="10" offsetY="0"/>
                 </Label>
@@ -208,27 +208,27 @@
                             <Anchor point="LEFT" relativeTo="$(parent)" relativePoint="LEFT" offsetX="0" offsetY="0"/>
                             <TextureCoords bottom="1" top="0" right="1" left="0"/>
                         </Texture>
-                        <Label name="$(parent)Quantity" horizontalAlignment="RIGHT" verticalAlignment="CENTER" inheritAlpha="true" text="1" color="FFFFFF" height="24" width="30" font="EsoUI/Common/Fonts/ProseAntiquePSMT.otf|15||soft-shadow-thin">
+                        <Label name="$(parent)Quantity" horizontalAlignment="RIGHT" verticalAlignment="CENTER" inheritAlpha="true" text="1" color="FFFFFF" height="24" width="30" font="$(ANTIQUE_FONT)|15||soft-shadow-thin">
                             <Anchor point="BOTTOMRIGHT" relativeTo="$(parent)Icon" relativePoint="BOTTOMRIGHT" offsetX="0" offsetY="2"/>
                         </Label>
-                        <Label name="$(parent)Text" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="LEFT" wrapMode="ELLIPSIS" lineSpacing="0" font="EsoUI/Common/Fonts/ProseAntiquePSMT.otf|15">
+                        <Label name="$(parent)Text" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="LEFT" wrapMode="ELLIPSIS" lineSpacing="0" font="$(ANTIQUE_FONT)|15">
                             <Dimensions x="280" />
                             <Anchor point="TOPLEFT" relativeTo="$(parent)Icon" relativePoint="TOPRIGHT" offsetX="5" offsetY="-4"/>
                             <Anchor point="BOTTOMRIGHT" relativeTo="$(parent)" relativePoint="BOTTOMRIGHT" offsetX="0" offsetY="0"/>
                         </Label>
                     </Controls>
                 </Control>
-                <Label name="$(parent)TimeStamp" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="RIGHT" wrapMode="ELLIPSIS" font="EsoUI/Common/Fonts/ProseAntiquePSMT.otf|15">
+                <Label name="$(parent)TimeStamp" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="RIGHT" wrapMode="ELLIPSIS" font="$(ANTIQUE_FONT)|15">
                     <Dimensions x="125" />
                     <Anchor point="TOPLEFT" relativeTo="$(parent)ItemLink" relativePoint="TOPRIGHT" offsetX="10" offsetY="0"/>
                     <Anchor point="BOTTOMLEFT" relativeTo="$(parent)ItemLink" relativePoint="BOTTOMRIGHT" offsetX="10" offsetY="0"/>
                 </Label>
-				<Label name="$(parent)UnitPrice" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="RIGHT" wrapMode="ELLIPSIS" font="EsoUI/Common/Fonts/ProseAntiquePSMT.otf|15">
+				<Label name="$(parent)UnitPrice" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="RIGHT" wrapMode="ELLIPSIS" font="$(ANTIQUE_FONT)|15">
                     <Dimensions x="85" />
                     <Anchor point="TOPLEFT" relativeTo="$(parent)TimeStamp" relativePoint="TOPRIGHT" offsetX="10" offsetY="0"/>
                     <Anchor point="BOTTOMLEFT" relativeTo="$(parent)TimeStamp" relativePoint="BOTTOMRIGHT" offsetX="10" offsetY="0"/>
                 </Label>
-                <Label name="$(parent)Price" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="RIGHT" wrapMode="ELLIPSIS" font="EsoUI/Common/Fonts/ProseAntiquePSMT.otf|15">
+                <Label name="$(parent)Price" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="RIGHT" wrapMode="ELLIPSIS" font="$(ANTIQUE_FONT)|15">
                     <Dimensions x="85" />
                     <Anchor point="TOPLEFT" relativeTo="$(parent)UnitPrice" relativePoint="TOPRIGHT" offsetX="10" offsetY="0"/>
                     <Anchor point="BOTTOMLEFT" relativeTo="$(parent)UnitPrice" relativePoint="BOTTOMRIGHT" offsetX="10" offsetY="0"/>

--- a/ArkadiusTradeToolsSales/ArkadiusTradeToolsSales.xml
+++ b/ArkadiusTradeToolsSales/ArkadiusTradeToolsSales.xml
@@ -159,15 +159,15 @@
         <Control name="ArkadiusTradeToolsSalesRow" inherits="ArkadiusTradeToolsListRow" virtual="true">
             <Controls>
                 <Texture name="$(parent)BG" inherits="ZO_ThinListBgStrip" />
-                <Label name="$(parent)SellerName" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="LEFT" wrapMode="ELLIPSIS" font="EsoUI/Common/Fonts/ProseAntiquePSMT.otf|15">
+                <Label name="$(parent)SellerName" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="LEFT" wrapMode="ELLIPSIS" font="$(ANTIQUE_FONT)|15">
                     <Anchor point="TOPLEFT" relativeTo="$(parent)" relativePoint="TOPLEFT" offsetX="0" offsetY="0"/>
                     <Anchor point="BOTTOMLEFT" relativeTo="$(parent)" relativePoint="BOTTOMLEFT" offsetX="0" offsetY="0"/>
                 </Label>
-                <Label name="$(parent)BuyerName" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="LEFT" wrapMode="ELLIPSIS" font="EsoUI/Common/Fonts/ProseAntiquePSMT.otf|15">
+                <Label name="$(parent)BuyerName" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="LEFT" wrapMode="ELLIPSIS" font="$(ANTIQUE_FONT)|15">
                     <Anchor point="TOPLEFT" relativeTo="$(parent)SellerName" relativePoint="TOPRIGHT" offsetX="10" offsetY="0"/>
                     <Anchor point="BOTTOMLEFT" relativeTo="$(parent)SellerName" relativePoint="BOTTOMRIGHT" offsetX="10" offsetY="0"/>
                 </Label>
-                <Label name="$(parent)GuildName" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="LEFT" wrapMode="ELLIPSIS" font="EsoUI/Common/Fonts/ProseAntiquePSMT.otf|15">
+                <Label name="$(parent)GuildName" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="LEFT" wrapMode="ELLIPSIS" font="$(ANTIQUE_FONT)|15">
                     <Anchor point="TOPLEFT" relativeTo="$(parent)BuyerName" relativePoint="TOPRIGHT" offsetX="10" offsetY="0"/>
                     <Anchor point="BOTTOMLEFT" relativeTo="$(parent)BuyerName" relativePoint="BOTTOMRIGHT" offsetX="10" offsetY="0"/>
                 </Label>
@@ -209,27 +209,27 @@
                             <Anchor point="LEFT" relativeTo="$(parent)" relativePoint="LEFT" offsetX="0" offsetY="0"/>
                             <TextureCoords bottom="1" top="0" right="1" left="0"/>
                         </Texture>
-                        <Label name="$(parent)Quantity" horizontalAlignment="RIGHT" verticalAlignment="CENTER" inheritAlpha="true" text="1" color="FFFFFF" height="24" width="30" font="EsoUI/Common/Fonts/ProseAntiquePSMT.otf|15||soft-shadow-thin">
+                        <Label name="$(parent)Quantity" horizontalAlignment="RIGHT" verticalAlignment="CENTER" inheritAlpha="true" text="1" color="FFFFFF" height="24" width="30" font="$(ANTIQUE_FONT)|15||soft-shadow-thin">
                             <Anchor point="BOTTOMRIGHT" relativeTo="$(parent)Icon" relativePoint="BOTTOMRIGHT" offsetX="0" offsetY="2"/>
                         </Label>
-                        <Label name="$(parent)Text" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="LEFT" lineSpacing="0" wrapMode="ELLIPSIS" font="EsoUI/Common/Fonts/ProseAntiquePSMT.otf|15">
+                        <Label name="$(parent)Text" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="LEFT" lineSpacing="0" wrapMode="ELLIPSIS" font="$(ANTIQUE_FONT)|15">
                             <Dimensions x="280" />
                             <Anchor point="TOPLEFT" relativeTo="$(parent)Icon" relativePoint="TOPRIGHT" offsetX="5" offsetY="-4"/>
                             <Anchor point="BOTTOMRIGHT" relativeTo="$(parent)" relativePoint="BOTTOMRIGHT" offsetX="0" offsetY="0"/>
                         </Label>
                     </Controls>
                 </Control>
-                <Label name="$(parent)TimeStamp" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="RIGHT" wrapMode="ELLIPSIS" font="EsoUI/Common/Fonts/ProseAntiquePSMT.otf|15">
+                <Label name="$(parent)TimeStamp" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="RIGHT" wrapMode="ELLIPSIS" font="$(ANTIQUE_FONT)|15">
                     <Dimensions x="125" />
                     <Anchor point="TOPLEFT" relativeTo="$(parent)ItemLink" relativePoint="TOPRIGHT" offsetX="10" offsetY="0"/>
                     <Anchor point="BOTTOMLEFT" relativeTo="$(parent)ItemLink" relativePoint="BOTTOMRIGHT" offsetX="10" offsetY="0"/>
                 </Label>
-				<Label name="$(parent)UnitPrice" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="RIGHT" wrapMode="ELLIPSIS" font="EsoUI/Common/Fonts/ProseAntiquePSMT.otf|15">
+				<Label name="$(parent)UnitPrice" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="RIGHT" wrapMode="ELLIPSIS" font="$(ANTIQUE_FONT)|15">
                     <Dimensions x="85" />
                     <Anchor point="TOPLEFT" relativeTo="$(parent)TimeStamp" relativePoint="TOPRIGHT" offsetX="10" offsetY="0"/>
                     <Anchor point="BOTTOMLEFT" relativeTo="$(parent)TimeStamp" relativePoint="BOTTOMRIGHT" offsetX="10" offsetY="0"/>
                 </Label>
-                <Label name="$(parent)Price" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="RIGHT" wrapMode="ELLIPSIS" font="EsoUI/Common/Fonts/ProseAntiquePSMT.otf|15">
+                <Label name="$(parent)Price" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="RIGHT" wrapMode="ELLIPSIS" font="$(ANTIQUE_FONT)|15">
                     <Dimensions x="85" />
                     <Anchor point="TOPLEFT" relativeTo="$(parent)UnitPrice" relativePoint="TOPRIGHT" offsetX="10" offsetY="0"/>
                     <Anchor point="BOTTOMLEFT" relativeTo="$(parent)UnitPrice" relativePoint="BOTTOMRIGHT" offsetX="10" offsetY="0"/>

--- a/ArkadiusTradeToolsStatistics/ArkadiusTradeToolsStatistics.xml
+++ b/ArkadiusTradeToolsStatistics/ArkadiusTradeToolsStatistics.xml
@@ -97,27 +97,27 @@
         <Control name="ArkadiusTradeToolsStatisticsRow" inherits="ArkadiusTradeToolsListRow" virtual="true">
             <Controls>
                 <Texture name="$(parent)BG" inherits="ZO_ThinListBgStrip" />
-                <Label name="$(parent)DisplayName" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="LEFT" wrapMode="ELLIPSIS" font="EsoUI/Common/Fonts/ProseAntiquePSMT.otf|15">
+                <Label name="$(parent)DisplayName" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="LEFT" wrapMode="ELLIPSIS" font="$(ANTIQUE_FONT)|15">
                     <Anchor point="TOPLEFT" relativeTo="$(parent)" relativePoint="TOPLEFT" offsetX="0" offsetY="0"/>
                     <Anchor point="BOTTOMLEFT" relativeTo="$(parent)" relativePoint="BOTTOMLEFT" offsetX="0" offsetY="0"/>
                 </Label>
-                <Label name="$(parent)GuildName" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="LEFT" wrapMode="ELLIPSIS" font="EsoUI/Common/Fonts/ProseAntiquePSMT.otf|15">
+                <Label name="$(parent)GuildName" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="LEFT" wrapMode="ELLIPSIS" font="$(ANTIQUE_FONT)|15">
                     <Anchor point="TOPLEFT" relativeTo="$(parent)DisplayName" relativePoint="TOPRIGHT" offsetX="10" offsetY="0"/>
                     <Anchor point="BOTTOMLEFT" relativeTo="$(parent)DisplayName" relativePoint="BOTTOMRIGHT" offsetX="10" offsetY="0"/>
                 </Label>
-                <Label name="$(parent)SalesVolume" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="RIGHT" wrapMode="ELLIPSIS" font="EsoUI/Common/Fonts/ProseAntiquePSMT.otf|15">
+                <Label name="$(parent)SalesVolume" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="RIGHT" wrapMode="ELLIPSIS" font="$(ANTIQUE_FONT)|15">
                     <Anchor point="TOPLEFT" relativeTo="$(parent)GuildName" relativePoint="TOPRIGHT" offsetX="10" offsetY="0"/>
                     <Anchor point="BOTTOMLEFT" relativeTo="$(parent)GuildName" relativePoint="BOTTOMRIGHT" offsetX="10" offsetY="0"/>
                 </Label>
-                <Label name="$(parent)Taxes" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="RIGHT" wrapMode="ELLIPSIS" font="EsoUI/Common/Fonts/ProseAntiquePSMT.otf|15">
+                <Label name="$(parent)Taxes" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="RIGHT" wrapMode="ELLIPSIS" font="$(ANTIQUE_FONT)|15">
                     <Anchor point="TOPLEFT" relativeTo="$(parent)SalesVolume" relativePoint="TOPRIGHT" offsetX="10" offsetY="0"/>
                     <Anchor point="BOTTOMLEFT" relativeTo="$(parent)SalesVolume" relativePoint="BOTTOMRIGHT" offsetX="10" offsetY="0"/>
                 </Label>
-                <Label name="$(parent)InternalSalesVolumePercentage" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="RIGHT" wrapMode="ELLIPSIS" font="EsoUI/Common/Fonts/ProseAntiquePSMT.otf|15">
+                <Label name="$(parent)InternalSalesVolumePercentage" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="RIGHT" wrapMode="ELLIPSIS" font="$(ANTIQUE_FONT)|15">
                     <Anchor point="TOPLEFT" relativeTo="$(parent)Taxes" relativePoint="TOPRIGHT" offsetX="10" offsetY="0"/>
                     <Anchor point="BOTTOMLEFT" relativeTo="$(parent)Taxes" relativePoint="BOTTOMRIGHT" offsetX="10" offsetY="0"/>
                 </Label>
-                <Label name="$(parent)ItemCount" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="RIGHT" wrapMode="ELLIPSIS" font="EsoUI/Common/Fonts/ProseAntiquePSMT.otf|15">
+                <Label name="$(parent)ItemCount" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="RIGHT" wrapMode="ELLIPSIS" font="$(ANTIQUE_FONT)|15">
                     <Anchor point="TOPLEFT" relativeTo="$(parent)InternalSalesVolumePercentage" relativePoint="TOPRIGHT" offsetX="10" offsetY="0"/>
                     <Anchor point="BOTTOMLEFT" relativeTo="$(parent)InternalSalesVolumePercentage" relativePoint="BOTTOMRIGHT" offsetX="10" offsetY="0"/>
                 </Label>


### PR DESCRIPTION
Replace font path with a dynamic fontString that will use appropriate fallbacks for cyrillic and asian writing systems.
See: `esoui/fontstrings` directory.

@timothymclane 