### PR TITLE
Fix cyrilic item link text

### DIFF
--- a/ArkadiusTradeToolsPurchases/ArkadiusTradeToolsPurchases.xml
+++ b/ArkadiusTradeToolsPurchases/ArkadiusTradeToolsPurchases.xml
@@ -211,7 +211,7 @@
                         <Label name="$(parent)Quantity" horizontalAlignment="RIGHT" verticalAlignment="CENTER" inheritAlpha="true" text="1" color="FFFFFF" height="24" width="30" font="$(ANTIQUE_FONT)|15||soft-shadow-thin">
                             <Anchor point="BOTTOMRIGHT" relativeTo="$(parent)Icon" relativePoint="BOTTOMRIGHT" offsetX="0" offsetY="2"/>
                         </Label>
-                        <Label name="$(parent)Text" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="LEFT" wrapMode="ELLIPSIS" lineSpacing="0" font="$(ANTIQUE_FONT)|15">
+                        <Label name="$(parent)Text" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="LEFT" wrapMode="ELLIPSIS" lineSpacing="0" font="$(GAMEPAD_BOLD_FONT)|17">
                             <Dimensions x="280" />
                             <Anchor point="TOPLEFT" relativeTo="$(parent)Icon" relativePoint="TOPRIGHT" offsetX="5" offsetY="-4"/>
                             <Anchor point="BOTTOMRIGHT" relativeTo="$(parent)" relativePoint="BOTTOMRIGHT" offsetX="0" offsetY="0"/>

--- a/ArkadiusTradeToolsSales/ArkadiusTradeToolsSales.xml
+++ b/ArkadiusTradeToolsSales/ArkadiusTradeToolsSales.xml
@@ -212,7 +212,7 @@
                         <Label name="$(parent)Quantity" horizontalAlignment="RIGHT" verticalAlignment="CENTER" inheritAlpha="true" text="1" color="FFFFFF" height="24" width="30" font="$(ANTIQUE_FONT)|15||soft-shadow-thin">
                             <Anchor point="BOTTOMRIGHT" relativeTo="$(parent)Icon" relativePoint="BOTTOMRIGHT" offsetX="0" offsetY="2"/>
                         </Label>
-                        <Label name="$(parent)Text" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="LEFT" lineSpacing="0" wrapMode="ELLIPSIS" font="$(ANTIQUE_FONT)|15">
+                        <Label name="$(parent)Text" inheritAlpha="true" verticalAlignment="CENTER" horizontalAlignment="LEFT" lineSpacing="0" wrapMode="ELLIPSIS" font="$(GAMEPAD_BOLD_FONT)|17">
                             <Dimensions x="280" />
                             <Anchor point="TOPLEFT" relativeTo="$(parent)Icon" relativePoint="TOPRIGHT" offsetX="5" offsetY="-4"/>
                             <Anchor point="BOTTOMRIGHT" relativeTo="$(parent)" relativePoint="BOTTOMRIGHT" offsetX="0" offsetY="0"/>


### PR DESCRIPTION
For whatever reason, ANTIQUE_FONT. is displayed incorrectly in some cases.

Change it to GAMEPAD_BOLD_FONT.

Before:
![ru-ANTIQUE](https://github.com/ArkadiusTradeTools/arkadius-trade-tools/assets/54838254/a3e9ae74-ed15-4864-93e6-2789b8d0da43)
![en-ANTIQUE](https://github.com/ArkadiusTradeTools/arkadius-trade-tools/assets/54838254/21c69a9c-02b5-4b99-aa74-d978ee046f46)

After:
![en-gamepad-bold](https://github.com/ArkadiusTradeTools/arkadius-trade-tools/assets/54838254/e1a6c764-cbfc-4789-b869-56d3a4f0630a)
![ru-gamepad-bold](https://github.com/ArkadiusTradeTools/arkadius-trade-tools/assets/54838254/76665394-1718-4400-881a-4d259c507d81)
